### PR TITLE
Block menu improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tiptap/starter-kit": "^2.0.0-beta.191",
         "@tiptap/vue-3": "^2.0.0-beta.96",
+        "fuse.js": "^6.6.2",
         "oh-vue-icons": "^1.0.0-rc3",
         "vue": "^3.2.37",
         "vue-draggable-next": "^2.1.1"
@@ -1315,6 +1316,14 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "node_modules/fuse.js": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -2971,6 +2980,11 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
+    },
+    "fuse.js": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA=="
     },
     "glob-parent": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@tiptap/starter-kit": "^2.0.0-beta.191",
     "@tiptap/vue-3": "^2.0.0-beta.96",
+    "fuse.js": "^6.6.2",
     "oh-vue-icons": "^1.0.0-rc3",
     "vue": "^3.2.37",
     "vue-draggable-next": "^2.1.1"

--- a/src/components/BlockMenu.vue
+++ b/src/components/BlockMenu.vue
@@ -58,6 +58,8 @@ document.addEventListener('click', (event:Event) => {
   if (!open.value) return
   if (!(container.value && container.value.contains(event.target as Node))) {
     open.value = false
+    searchTerm.value = ''
+    active.value = 0
   }
 })
 

--- a/src/components/BlockMenu.vue
+++ b/src/components/BlockMenu.vue
@@ -40,6 +40,7 @@
 
 <script setup lang="ts">
 import { ref, computed, PropType } from 'vue'
+import Fuse from 'fuse.js'
 import { BlockType } from '@/utils/types'
 import Tooltip from './elements/Tooltip.vue'
 
@@ -104,30 +105,39 @@ document.addEventListener('keydown', (event:KeyboardEvent) => {
 /*
 Menu options
 */
+
+const defaultOptions = [
+  {
+    type: 'Turn into',
+    icon: 'bi-text-left',
+    label: 'Text',
+    callback: () => setBlockType(BlockType.Text),
+  }, {
+    type: 'Turn into',
+    icon: 'bi-type-h1',
+    label: 'Heading 1',
+    callback: () => setBlockType(BlockType.H1),
+  }, {
+    type: 'Turn into',
+    icon: 'bi-type-h2',
+    label: 'Heading 2',
+    callback: () => setBlockType(BlockType.H2),
+  }, {
+    type: 'Turn into',
+    icon: 'bi-hr',
+    label: 'Divider',
+    callback: () => setBlockType(BlockType.Divider),
+  },
+]
+
+const fuzzySearch = new Fuse(defaultOptions, {
+  keys: ['label']
+})
+
 const options = computed(() => {
-  return [
-    {
-      type: 'Turn into',
-      icon: 'bi-text-left',
-      label: 'Text',
-      callback: () => setBlockType(BlockType.Text),
-    }, {
-      type: 'Turn into',
-      icon: 'bi-type-h1',
-      label: 'Heading 1',
-      callback: () => setBlockType(BlockType.H1),
-    }, {
-      type: 'Turn into',
-      icon: 'bi-type-h2',
-      label: 'Heading 2',
-      callback: () => setBlockType(BlockType.H2),
-    }, {
-      type: 'Turn into',
-      icon: 'bi-hr',
-      label: 'Divider',
-      callback: () => setBlockType(BlockType.Divider),
-    },
-  ].filter(option => option.label.toLowerCase().startsWith(searchTerm.value))
+  return searchTerm.value === ''
+    ? defaultOptions
+    : fuzzySearch.search(searchTerm.value).map(result => result.item)
 })
 
 function setBlockType (blockType:BlockType) {

--- a/src/components/BlockMenu.vue
+++ b/src/components/BlockMenu.vue
@@ -87,7 +87,9 @@ document.addEventListener('keydown', (event:KeyboardEvent) => {
   } else if (event.key === 'Escape') {
     // Escape closes menu
     open.value = false
-  } else if (event.key.match(/^([a-zA-Z]|[0-9])$/)) {
+    searchTerm.value = ''
+    active.value = 0
+  } else if (event.key.match(/^([a-zA-Z]|[0-9]| )$/)) {
     // Alphanumeric searches menu
     searchTerm.value += event.key
     active.value = 0


### PR DESCRIPTION
This pull request:

- Makes search more convenient by using fuzzy search instead of `String#startsWith`
- Fixes a bug of search term not being set back to an empty string when user presses `Esc` or clicks outside the block menu
- Fixes spaces being ignored when a user inputs a search query. Notion doesn't ignore spaces (you can type `/heading 1` and it will work)