### PR TITLE
Clear search only if there is searchTerm

### DIFF
--- a/src/components/Block.vue
+++ b/src/components/Block.vue
@@ -434,6 +434,9 @@ function parseMarkdown (event:KeyboardEvent) {
 }
 
 function clearSearch (searchTermLength: number) {
+  if (searchTermLength <= 1)
+    return
+
   const pos = getCaretPosWithoutTags().pos
   const startIdx = pos - searchTermLength - 1
   const endIdx = pos

--- a/src/components/BlockMenu.vue
+++ b/src/components/BlockMenu.vue
@@ -147,8 +147,10 @@ const options = computed(() => {
 })
 
 function setBlockType (blockType:BlockType) {
-  emit('clearSearch', searchTerm.value.length)
+  if (searchTerm.value.length > 0)
+    emit('clearSearch', searchTerm.value.length)
   emit('setBlockType', blockType)
+
   searchTerm.value = ''
   open.value = false
 }


### PR DESCRIPTION
There is no need to send event to clear search term if there is none.

This also fixes bug that removed last character when transforming from Text into Heading. Should I also create issue for this?