### PR TITLE
fix: drag & drop issues

### DIFF
--- a/src/components/Block.vue
+++ b/src/components/Block.vue
@@ -20,6 +20,7 @@
           class="w-6 h-6 hover:bg-neutral-100 hover:text-neutral-400 p-0.5 rounded group-hover:opacity-100 opacity-0" />
       </Tooltip>
       <BlockMenu ref="menu"
+        class="handle"
         @setBlockType="type => emit('setBlockType', type)"
         @clearSearch="clearSearch"
         />

--- a/src/components/Lotion.vue
+++ b/src/components/Lotion.vue
@@ -5,7 +5,7 @@
       :class="props.page.name ? '' : 'empty'">
       {{ props.page.name || '' }}
     </h1>
-    <draggable tag="div" :list="props.page.blocks"
+    <draggable tag="div" :list="props.page.blocks"  handle=".handle"
       v-bind="dragOptions" class="-ml-24 space-y-2 pb-4">
       <transition-group type="transition">
         <BlockComponent :block="block" v-for="block, i in props.page.blocks" :key="i"

--- a/src/components/elements/Editor.vue
+++ b/src/components/elements/Editor.vue
@@ -43,6 +43,11 @@ onMounted(() => {
       Italic,
       History,
     ],
+    editorProps: { 
+      handleDrop : (view, event, slice, moved) => {
+       return true;
+      }
+    },
     content: props.modelValue,
     onUpdate: () => {
       emit('update:modelValue', editor.value?.getHTML().replaceAll(/\<br.*?\>/g, ''))


### PR DESCRIPTION
Proposed solution for #10 
### Using handle property for draggable
Associating handle with `BlockMenu` component ensures that blocks can be dragged only when the user is dragging the BlockMenu icon, instead of anywhere on the div. Mirrors actual notion behaviour. [Example](https://sortablejs.github.io/Vue.Draggable/#/handle)

### Removing default behaviour for drop event
Issue where dropping a block inside itself would result in unwanted behaviour, seems to be caused by the HTML `drop` event on the editor. Preventing the default drop event inside the editor seems to fix the issue.

Side note: The following solution seems more clear, but it throws a typescript error for some reason. 
Current code does the same  [(Reference)](https://github.com/ProseMirror/prosemirror-view/blob/master/src/index.ts#L521)
```javascript
    editorProps: { 
      handleDOMEvents : {
        drop: (view, event) => {event.preventDefault()}
      }
    }
```

### Comparisons:
<details>
  <summary>Handle</summary>

![draghandle-before](https://user-images.githubusercontent.com/45852430/182029948-4ec95a41-bccf-4d54-b8ca-d55b5111b77f.gif)
![draghandle-after](https://user-images.githubusercontent.com/45852430/182030048-eaccceae-31d3-4e43-8b89-ba6a7f54e8bd.gif)
</details>
<details>
  <summary>Drop</summary>

![drop-before](https://user-images.githubusercontent.com/45852430/182030073-6b772d87-d83b-4b78-a2b6-c93e2a10935c.gif)
![drop-after](https://user-images.githubusercontent.com/45852430/182030096-ca3cb4a1-2c5d-4f14-a352-09144c380c93.gif)
</details>


