### PR TITLE
fix: heading block merge issues

### DIFF
--- a/src/components/Block.vue
+++ b/src/components/Block.vue
@@ -93,7 +93,7 @@ function getInnerContent () {
   if (props.block.type === BlockType.Text) {
     return (content.value as any).$el.firstChild.firstChild.firstChild
   } else {
-    return (content.value as any).$el.firstChild || content.value.$el
+    return (content.value as any).$el.firstChild;
   }
 }
 
@@ -105,6 +105,7 @@ function getTextContent () {
 function getHtmlContent () {
   const innerContent = getInnerContent()
   if (innerContent) return innerContent.parentElement.innerHTML
+  else return ""
 }
 
 function keyDownHandler (event:KeyboardEvent) {

--- a/src/components/Lotion.vue
+++ b/src/components/Lotion.vue
@@ -93,7 +93,7 @@ function merge (blockIdx: number) {
       blockElements.value[blockIdx-1].setCaretPos(prevBlockContentLength)
       props.page.blocks.splice(blockIdx, 1)
     })
-  } else if ([BlockType.H1, BlockType.H2].includes(props.page.blocks[blockIdx-1].type)) {
+  } else if ([BlockType.H1, BlockType.H2, BlockType.H3].includes(props.page.blocks[blockIdx-1].type)) {
     const prevBlockContentLength = (props.page.blocks[blockIdx-1] as any).details.value.length
     props.page.blocks[blockIdx-1].details.value += blockElements.value[blockIdx].getTextContent()
     setTimeout(() => {


### PR DESCRIPTION
- fixed minor issue where user could not merge into h3 after #8 
- proposed solution for #20 
  - `innerContent()` would previously return the parent div when `firstChild === null` (occured when block was a header type and content was empty), which got merged into previous block if previous block was a text

<details>
  <summary>comparison</summary>

![hmerge-before](https://user-images.githubusercontent.com/45852430/182114359-fdf94eee-b855-4f52-ad56-27f8d2c33049.gif)

![hmerge-after](https://user-images.githubusercontent.com/45852430/182114384-b05f4b4a-1e81-4aac-9170-ea84c5bb04d6.gif)

</details>
  