### PR TITLE
Fix outline style in Safari

### DIFF
--- a/src/components/elements/Editor.vue
+++ b/src/components/elements/Editor.vue
@@ -49,3 +49,9 @@ watch(() => props.modelValue, value => {
   editor.value?.commands.setContent(value, false)
 })
 </script>
+
+<style scoped>
+:deep([contenteditable="true"]:focus) {
+  outline: none;
+}
+</style>


### PR DESCRIPTION
Before:

<img width="1376" alt="截屏2022-08-02 上午9 27 12" src="https://user-images.githubusercontent.com/23100055/182272400-6888c93b-48fa-4646-beb6-a3a49b5bdf47.png">

After:

<img width="1376" alt="截屏2022-08-02 上午9 27 41" src="https://user-images.githubusercontent.com/23100055/182272419-4889a53d-76bd-48f8-a8c9-68d5b6c0d838.png">
