### PR TITLE
fix: block conversion issues

### DIFF
--- a/src/components/Block.vue
+++ b/src/components/Block.vue
@@ -444,7 +444,7 @@ function parseMarkdown (event:KeyboardEvent) {
 }
 
 function clearSearch (searchTermLength: number) {
-  if (searchTermLength <= 1)
+  if (searchTermLength < 1)
     return
   const pos = getCaretPosWithoutTags().pos
   const startIdx = pos - searchTermLength - 1

--- a/src/components/Block.vue
+++ b/src/components/Block.vue
@@ -305,6 +305,11 @@ function getCaretPos () {
         selectedNode = selectedNode?.parentElement as Node
         tag = (selectedNode as HTMLElement).tagName.toLowerCase()
       }
+      // Edge case when character length is 1
+      if (selectedNode !== null && selectedNode.childNodes.length > 0) {
+        if (selectedNode.childNodes[0].textContent && selectedNode.childNodes[0].textContent.length <= 1)
+          selectedNode = selectedNode.childNodes[0];
+      }
       for (const [i, node] of (content.value as any).$el.firstChild.firstChild.childNodes.entries()) {
         if (node === selectedNode) {
           offsetNode = node
@@ -333,6 +338,11 @@ function getCaretPosWithoutTags () {
       if (['STRONG', 'EM'].includes(selectedNode?.parentElement?.tagName as string)) {
         selectedNode = selectedNode?.parentElement as Node
         tag = (selectedNode as HTMLElement).tagName.toLowerCase()
+      }
+      // Edge case when character length is 1
+      if (selectedNode !== null && selectedNode.childNodes.length > 0) {
+        if (selectedNode.childNodes[0].textContent && selectedNode.childNodes[0].textContent.length <= 1)
+          selectedNode = selectedNode.childNodes[0];
       }
       for (const [i, node] of (content.value as any).$el.firstChild.firstChild.childNodes.entries()) {
         if (node === selectedNode) {

--- a/src/components/Block.vue
+++ b/src/components/Block.vue
@@ -20,7 +20,6 @@
           class="w-6 h-6 hover:bg-neutral-100 hover:text-neutral-400 p-0.5 rounded group-hover:opacity-100 opacity-0" />
       </Tooltip>
       <BlockMenu ref="menu"
-        class="handle"
         @setBlockType="type => emit('setBlockType', type)"
         @clearSearch="clearSearch"
         />

--- a/src/components/Block.vue
+++ b/src/components/Block.vue
@@ -443,8 +443,9 @@ function parseMarkdown (event:KeyboardEvent) {
   }
 }
 
-function clearSearch (searchTermLength: number) {
-  if (searchTermLength < 1)
+function clearSearch (searchTermLength: number, openedWithSlash: boolean = false) {
+  // If openedWithSlash, searchTermLength = 0 but we still need to clear
+  if (searchTermLength < 1 && !openedWithSlash) 
     return
   const pos = getCaretPosWithoutTags().pos
   const startIdx = pos - searchTermLength - 1

--- a/src/components/BlockMenu.vue
+++ b/src/components/BlockMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="container" as="div" class="relative w-max h-max">
-    <div @click="open = !open">
+    <div @click="open = !open" class="handle">
       <Tooltip value="<span class='text-neutral-400'><span class='text-white'>Drag</span> to move<br/><span class='text-white'>Click</span> to open menu</span>">
         <v-icon name="md-dragindicator" @mouseup="$event.stopPropagation()"
           class="w-6 h-6 hover:bg-neutral-100 hover:text-neutral-400 p-0.5 rounded group-hover:opacity-100 opacity-0"

--- a/src/components/BlockMenu.vue
+++ b/src/components/BlockMenu.vue
@@ -157,7 +157,7 @@ const options = computed(() => {
 
 function setBlockType (blockType:BlockType) {
   if (searchTerm.value.length > 0 || openedWithSlash.value)
-    emit('clearSearch', searchTerm.value.length)
+    emit('clearSearch', searchTerm.value.length, openedWithSlash.value)
   emit('setBlockType', blockType)
 
   searchTerm.value = ''


### PR DESCRIPTION
Proposed solutions for #27 and #29

For #27,  `Block.vue::clearSearch` previously wouldn't trigger on a single slash since the slash was not added to `searchTerm`. Also changed <= 1 to <1 to support single character search terms (e.g. /h)

For #29 please see issue 

<details>
  <summary>27</summary>

![27-before](https://user-images.githubusercontent.com/45852430/182354053-44d0b10a-f9aa-44f0-be52-f9e5bc2f6687.gif)
![27-after](https://user-images.githubusercontent.com/45852430/182354066-4541a060-9732-434d-8eb4-90a83e9d3a6c.gif)
</details>
<details>
  <summary>29</summary>

![29-before](https://user-images.githubusercontent.com/45852430/182353990-6666bfbb-1e7d-4f28-b0f1-88a2d0422cd4.gif)
![29-after](https://user-images.githubusercontent.com/45852430/182354007-8a807c15-ceb0-4d9e-9e32-dc3e6c2021d6.gif)

</details>