### PR TITLE
fix: quote block logic

### DIFF
--- a/src/components/Block.vue
+++ b/src/components/Block.vue
@@ -63,7 +63,7 @@ const emit = defineEmits([
 ])
 
 function getFirstChild () {
-  if (props.block.type === BlockType.Text) {
+  if (props.block.type === BlockType.Text || props.block.type === BlockType.Quote) {
     if ((content.value as any).$el.firstChild.firstChild.childNodes.length > 1) {
       return (content.value as any).$el.firstChild.firstChild.firstChild
     } else {
@@ -76,7 +76,7 @@ function getFirstChild () {
 }
 
 function getLastChild () {
-  if (props.block.type === BlockType.Text) {
+  if (props.block.type === BlockType.Text || props.block.type === BlockType.Quote) {
     if ((content.value as any).$el.firstChild.firstChild.childNodes.length > 1) {
       return (content.value as any).$el.firstChild.firstChild.lastChild
     } else {
@@ -89,7 +89,7 @@ function getLastChild () {
 }
 
 function getInnerContent () {
-  if (props.block.type === BlockType.Text) {
+  if (props.block.type === BlockType.Text || props.block.type === BlockType.Quote) {
     return (content.value as any).$el.firstChild.firstChild.firstChild
   } else {
     return (content.value as any).$el.firstChild
@@ -152,7 +152,7 @@ function keyDownHandler (event:KeyboardEvent) {
 }
 
 function isContentBlock () {
-  return [BlockType.Text, BlockType.H1, BlockType.H2, BlockType.H3].includes(props.block.type)
+  return [BlockType.Text, BlockType.Quote, BlockType.H1, BlockType.H2, BlockType.H3].includes(props.block.type)
 }
 
 const content = ref<any>(null)
@@ -298,7 +298,7 @@ function getCaretCoordinates () {
 function getCaretPos () {
   const selection = window.getSelection()
   if (selection) {
-    if (props.block.type === BlockType.Text) {
+    if (props.block.type === BlockType.Text || props.block.type === BlockType.Quote) {
       let offsetNode, offset = 0, tag = null
       let selectedNode = selection.anchorNode
       if (['STRONG', 'EM'].includes(selectedNode?.parentElement?.tagName as string)) {
@@ -332,7 +332,7 @@ function getCaretPos () {
 function getCaretPosWithoutTags () {
   const selection = window.getSelection()
   if (selection) {
-    if (props.block.type === BlockType.Text) {
+    if (props.block.type === BlockType.Text || props.block.type === BlockType.Quote) {
       let offsetNode, offset = 0, tag = null
       let selectedNode = selection.anchorNode
       if (['STRONG', 'EM'].includes(selectedNode?.parentElement?.tagName as string)) {
@@ -364,7 +364,7 @@ function getCaretPosWithoutTags () {
 function setCaretPos (caretPos:number) {
   const innerContent = getInnerContent()
   if (innerContent) {
-    if (props.block.type === BlockType.Text) {
+    if (props.block.type === BlockType.Text || props.block.type === BlockType.Quote) {
       let offsetNode, offset = 0
       const numNodes = (content.value as any).$el.firstChild.firstChild.childNodes.length
       for (const [i, node] of (content.value as any).$el.firstChild.firstChild.childNodes.entries()) {
@@ -463,7 +463,7 @@ function clearSearch (searchTermLength: number, openedWithSlash: boolean = false
   setTimeout(() => {
     const originalText = (content.value as any).$el.innerText
     props.block.details.value = originalText.substring(0, startIdx) + originalText.substring(endIdx);
-    if (props.block.type === BlockType.Text) {
+    if (props.block.type === BlockType.Text || props.block.type === BlockType.Quote) {
       props.block.details.value = `<p>${originalText.substring(0, startIdx) + originalText.substring(endIdx)}</p>`
     } else {
       (content.value as any).$el.innerText = originalText.substring(0, startIdx) + originalText.substring(endIdx)

--- a/src/components/Lotion.vue
+++ b/src/components/Lotion.vue
@@ -82,7 +82,7 @@ function deleteBlock (blockIdx: number) {
 }
 
 function setBlockType (blockIdx: number, type: BlockType) {
-  if (props.page.blocks[blockIdx].type === BlockType.Text) {
+  if (props.page.blocks[blockIdx].type === BlockType.Text || props.page.blocks[blockIdx].type === BlockType.Quote) {
     props.page.blocks[blockIdx].details.value = blockElements.value[blockIdx].getTextContent()
   }
   props.page.blocks[blockIdx].type = type
@@ -95,7 +95,7 @@ function setBlockType (blockIdx: number, type: BlockType) {
 function merge (blockIdx: number) {
   if (blockIdx === 0) return
 
-  if (props.page.blocks[blockIdx-1].type === BlockType.Text) {
+  if (props.page.blocks[blockIdx-1].type === BlockType.Text || props.page.blocks[blockIdx-1].type === BlockType.Quote) {
     const prevBlockContentLength = blockElements.value[blockIdx-1].getTextContent().length
     props.page.blocks[blockIdx-1].details.value = ('<p>' + (props.page.blocks[blockIdx-1] as any).details.value.replace('<p>', '').replace('</p>', '') + blockElements.value[blockIdx].getHtmlContent().replaceAll(/\<br.*?\>/g, '').replace('<p>', '').replace('</p>', '') + '</p>').replace('</strong><strong>', '').replace('</em><em>', '')
     setTimeout(() => {
@@ -119,7 +119,7 @@ function split (blockIdx: number) {
   const caretPos = blockElements.value[blockIdx].getCaretPos()
   insertBlock(blockIdx)
   props.page.blocks[blockIdx+1].details.value = (caretPos.tag ? `<p><${caretPos.tag}>` : '<p>') + props.page.blocks[blockIdx].details.value?.slice(caretPos.pos)
-  if (props.page.blocks[blockIdx].type === BlockType.Text) {
+  if (props.page.blocks[blockIdx].type === BlockType.Text || props.page.blocks[blockIdx].type === BlockType.Quote) {
     props.page.blocks[blockIdx].details.value = props.page.blocks[blockIdx].details.value?.slice(0, caretPos.pos) + (caretPos.tag ? `</${caretPos.tag}></p>` : '</p>')
   } else {
     props.page.blocks[blockIdx].details.value = props.page.blocks[blockIdx].details.value?.slice(0, caretPos.pos) + (caretPos.tag ? `</${caretPos.tag}></p>` : '')

--- a/src/components/Markdown.vue
+++ b/src/components/Markdown.vue
@@ -17,9 +17,9 @@ const props = defineProps({
 
 const markdownBlocks = computed(() => {
   return props.page.blocks.map(block => {
-    if (block.type === BlockType.Text) {
+    if (block.type === BlockType.Text || block.type === BlockType.Quote) {
       return {
-        type: BlockType.Text,
+        type: block.type,
         details: {
           value: (block.details.value as string)
             .replaceAll('<p>', '')


### PR DESCRIPTION
Added missing logic for merge/split/etc operations for new quote block in #32 

<details>
<summary>video</summary>

![quotefix](https://user-images.githubusercontent.com/45852430/182512347-a50f46d6-bbcc-4722-9531-28ae2aee1797.gif)
</details>