### PR TITLE
fix: merge empty heading block into another heading block

### DIFF
--- a/src/components/Block.vue
+++ b/src/components/Block.vue
@@ -99,6 +99,7 @@ function getInnerContent () {
 function getTextContent () {
   const innerContent = getInnerContent()
   if (innerContent) return innerContent.parentElement ? innerContent.parentElement.textContent : innerContent.textContent
+  else return ''
 }
 
 function getHtmlContent () {


### PR DESCRIPTION
solves #35 

<details>
<summary>comparison</summary>

![mergeintoheading-before](https://user-images.githubusercontent.com/45852430/182515128-8d34d2a4-4a45-40c7-800e-32213d7efc24.gif)
![mergeintoheading-after](https://user-images.githubusercontent.com/45852430/182515574-fb86441c-d56c-447d-98f4-3e08fb53f1bc.gif)
</details>