### PR TITLE
fix: make bold and italic tags persist after block conversion (text type)

### DIFF
--- a/src/components/Block.vue
+++ b/src/components/Block.vue
@@ -464,16 +464,44 @@ function clearSearch (searchTermLength: number, openedWithSlash: boolean = false
   // If openedWithSlash, searchTermLength = 0 but we still need to clear
   if (searchTermLength < 1 && !openedWithSlash) 
     return
-  const pos = getCaretPosWithoutTags().pos
-  const startIdx = pos - searchTermLength - 1
-  const endIdx = pos
+
+  let pos:number, startIdx:number, endIdx:number;
+  let finalText:string, finalTextWithTags:string = '';
+  // Refers to current block type before change
+  if (props.block.type === BlockType.Text || props.block.type === BlockType.Quote) {
+    pos = getCaretPos().pos;
+    // Subtract extra 3 for <p> in front
+    startIdx = pos - searchTermLength - 4;
+    endIdx = pos - 3;
+    const htmlContent = getHtmlContent();
+    finalTextWithTags = htmlContent.substring(0, startIdx) + htmlContent.substring(endIdx);
+  } 
+  pos = getCaretPosWithoutTags().pos
+  startIdx = pos - searchTermLength - 1
+  endIdx = pos
+  const textContent = getTextContent()
+  finalText = textContent.substring(0, startIdx) + textContent.substring(endIdx)
+
   setTimeout(() => {
+<<<<<<< HEAD
     const originalText = (content.value as any).$el.innerText
     props.block.details.value = originalText.substring(0, startIdx) + originalText.substring(endIdx);
     if (isTextBlock(props.block.type)) {
       props.block.details.value = `<p>${originalText.substring(0, startIdx) + originalText.substring(endIdx)}</p>`
+=======
+    // Refers to block type after change
+    if (props.block.type === BlockType.Text || props.block.type === BlockType.Quote) {
+      if (finalTextWithTags !== '') {
+        props.block.details.value = '<p>' + finalTextWithTags + '</p>'
+      } else {
+        // We came from a heading type, so use plain text
+        props.block.details.value = '<p>' + finalText + '</p>'
+      }
+    } else if (props.block.type === BlockType.Divider) {
+      props.block.details = {}
+>>>>>>> Modified clearSearch behaviour to allow <strong> and <em> tags to persist after block type change
     } else {
-      (content.value as any).$el.innerText = originalText.substring(0, startIdx) + originalText.substring(endIdx)
+      props.block.details.value = finalText
     }
     setTimeout(() => setCaretPos(startIdx))
   })

--- a/src/components/Block.vue
+++ b/src/components/Block.vue
@@ -468,7 +468,7 @@ function clearSearch (searchTermLength: number, openedWithSlash: boolean = false
   let pos:number, startIdx:number, endIdx:number;
   let finalText:string, finalTextWithTags:string = '';
   // Refers to current block type before change
-  if (props.block.type === BlockType.Text || props.block.type === BlockType.Quote) {
+  if (isTextBlock(props.block.type)) {
     pos = getCaretPos().pos;
     // Subtract extra 3 for <p> in front
     startIdx = pos - searchTermLength - 4;
@@ -483,14 +483,8 @@ function clearSearch (searchTermLength: number, openedWithSlash: boolean = false
   finalText = textContent.substring(0, startIdx) + textContent.substring(endIdx)
 
   setTimeout(() => {
-<<<<<<< HEAD
-    const originalText = (content.value as any).$el.innerText
-    props.block.details.value = originalText.substring(0, startIdx) + originalText.substring(endIdx);
-    if (isTextBlock(props.block.type)) {
-      props.block.details.value = `<p>${originalText.substring(0, startIdx) + originalText.substring(endIdx)}</p>`
-=======
     // Refers to block type after change
-    if (props.block.type === BlockType.Text || props.block.type === BlockType.Quote) {
+    if (isTextBlock(props.block.type)) {
       if (finalTextWithTags !== '') {
         props.block.details.value = '<p>' + finalTextWithTags + '</p>'
       } else {
@@ -499,7 +493,6 @@ function clearSearch (searchTermLength: number, openedWithSlash: boolean = false
       }
     } else if (props.block.type === BlockType.Divider) {
       props.block.details = {}
->>>>>>> Modified clearSearch behaviour to allow <strong> and <em> tags to persist after block type change
     } else {
       props.block.details.value = finalText
     }

--- a/src/components/Lotion.vue
+++ b/src/components/Lotion.vue
@@ -84,7 +84,20 @@ function deleteBlock (blockIdx: number) {
 }
 
 function setBlockType (blockIdx: number, type: BlockType) {
+<<<<<<< HEAD
   props.page.blocks[blockIdx].details.value = blockElements.value[blockIdx].getTextContent()
+=======
+  if (props.page.blocks[blockIdx].type === BlockType.Text || props.page.blocks[blockIdx].type === BlockType.Quote) {
+    // If target is text or quote, keep <strong> and <em> tags, and add <p> tags
+    if (type === BlockType.Text || type === BlockType.Quote) {
+      props.page.blocks[blockIdx].details.value = '<p>' + blockElements.value[blockIdx].getHtmlContent() + '</p>'
+    }
+    else { 
+      // If not, we can just get the text content
+      props.page.blocks[blockIdx].details.value = blockElements.value[blockIdx].getTextContent()
+    }
+  }
+>>>>>>> Keep <strong> and <em> tags upon block type change with no search term
   props.page.blocks[blockIdx].type = type
   if (type === BlockType.Divider) {
     props.page.blocks[blockIdx].details = {}

--- a/src/components/Lotion.vue
+++ b/src/components/Lotion.vue
@@ -84,12 +84,9 @@ function deleteBlock (blockIdx: number) {
 }
 
 function setBlockType (blockIdx: number, type: BlockType) {
-<<<<<<< HEAD
-  props.page.blocks[blockIdx].details.value = blockElements.value[blockIdx].getTextContent()
-=======
-  if (props.page.blocks[blockIdx].type === BlockType.Text || props.page.blocks[blockIdx].type === BlockType.Quote) {
+  if (isTextBlock(props.page.blocks[blockIdx].type)) {
     // If target is text or quote, keep <strong> and <em> tags, and add <p> tags
-    if (type === BlockType.Text || type === BlockType.Quote) {
+    if (isTextBlock(type)) {
       props.page.blocks[blockIdx].details.value = '<p>' + blockElements.value[blockIdx].getHtmlContent() + '</p>'
     }
     else { 
@@ -97,7 +94,6 @@ function setBlockType (blockIdx: number, type: BlockType) {
       props.page.blocks[blockIdx].details.value = blockElements.value[blockIdx].getTextContent()
     }
   }
->>>>>>> Keep <strong> and <em> tags upon block type change with no search term
   props.page.blocks[blockIdx].type = type
   if (type === BlockType.Divider) {
     props.page.blocks[blockIdx].details = {}


### PR DESCRIPTION
Currently, converting between text type blocks (text <-> quote / text->text / quote->quote) results in loss of bold and italic tags
- Modified `Lotion.vue::setBlockType` to use html content instead of text content when target block is text/quote (solves conversion with no search)
- Modified `Block.vue::clearSearch` to take into account html content - now if type of block before conversion is text/quote, it will store the html content in addition to the text content, and if the type of block after conversion is text/quote, it will use the stored html content. (solves conversion via search)

<details>
<summary>video</summary>

![keeptags-before](https://user-images.githubusercontent.com/45852430/182750133-8318e3a9-8364-4f02-b7fd-0ee1695eda77.gif)
![keeptags-after](https://user-images.githubusercontent.com/45852430/182750242-248dcb1c-bd3b-499c-8944-2c7ae01b69a4.gif)
</details>

Tags are still lost when converting to heading types, could potentially find a workaround with the current implementation but @holazz's refactor in #39 will potentially make it much easier (I think we would be able to use the same logic as text blocks)