### PR TITLE
fix: make bold and italic tags persist after block conversion (text type)

### DIFF
--- a/src/components/Lotion.vue
+++ b/src/components/Lotion.vue
@@ -84,7 +84,16 @@ function deleteBlock (blockIdx: number) {
 }
 
 function setBlockType (blockIdx: number, type: BlockType) {
-  props.page.blocks[blockIdx].details.value = blockElements.value[blockIdx].getTextContent()
+   if (isTextBlock(props.page.blocks[blockIdx].type)) {
+    // If target is text or quote, keep <strong> and <em> tags, and add <p> tags
+    if (isTextBlock(type)) {
+      props.page.blocks[blockIdx].details.value = '<p>' + blockElements.value[blockIdx].getHtmlContent() + '</p>'
+    }
+    else {
+      // If not, we can just get the text content
+      props.page.blocks[blockIdx].details.value = blockElements.value[blockIdx].getTextContent()
+    }
+  }
   props.page.blocks[blockIdx].type = type
   if (type === BlockType.Divider) {
     props.page.blocks[blockIdx].details = {}


### PR DESCRIPTION
Currently, converting between text type blocks (text <-> quote / text->text / quote->quote) results in loss of bold and italic tags
- Modified `Lotion.vue::setBlockType` to use html content instead of text content when target block is text/quote (solves conversion with no search)
- Modified `Block.vue::clearSearch` to take into account html content - now if type of block before conversion is text/quote, it will store the html content in addition to the text content, and if the type of block after conversion is text/quote, it will use the stored html content. (solves conversion via search)

<details>
<summary>video</summary>

![keeptags-before](https://user-images.githubusercontent.com/45852430/182750133-8318e3a9-8364-4f02-b7fd-0ee1695eda77.gif)
![keeptags-after](https://user-images.githubusercontent.com/45852430/182750242-248dcb1c-bd3b-499c-8944-2c7ae01b69a4.gif)
</details>

Tags are still lost when converting to heading types, could potentially find a workaround with the current implementation but @holazz's refactor in #39 will potentially make it much easier (I think we would be able to use the same logic as text blocks)