### PR TITLE
Ordered and Unordered List block

### DIFF
--- a/src/components/Block.vue
+++ b/src/components/Block.vue
@@ -4,15 +4,12 @@
       // Add top margin for headings
       'pt-12 first:pt-0': block.type === BlockType.H1,
       'pt-4 first:pt-0': block.type === BlockType.H2,
-      'list-item ml-5 list-disc': block.type === BlockType.UnorderedList,
-      'list-item ml-5 list-decimal': block.type === BlockType.OrderedList,
     }"
   >
     <div class="group relative w-full rounded mr-32">
       <div
-        class="h-full absolute min-h-[2rem] top-1/2 pl-4 pr-2 text-center cursor-pointer transition-opacity duration-150 text-neutral-300 z-10 flex -translate-y-1/2"
+        class="h-full absolute min-h-[2rem] top-1/2 pl-4 pr-2 text-center cursor-pointer transition-opacity duration-150 text-neutral-300 z-10 flex -translate-y-1/2 -left-24"
         :class="[
-          [BlockType.OrderedList, BlockType.UnorderedList].includes(block.type) ? '-left-[7.25rem]' : '-left-24',
           {
             'invisible': props.readonly,
             'py-3.5': block.type === BlockType.H1,
@@ -35,8 +32,17 @@
           :blockTypes="props.block.details.blockTypes || props.blockTypes"
         />
       </div>
-      <div class="w-full relative" :class="{ 'px-0': block.type !== BlockType.Divider }">
-        <!-- Actual content -->
+      <div
+        class="w-full relative list-marker"
+        :data-index="listIndex"
+        :class="{
+          'px-0': block.type !== BlockType.Divider,
+          'pl-9': [BlockType.UnorderedList, BlockType.OrderedList].includes(block.type),
+          'ordered-list': block.type === BlockType.OrderedList,
+          'unordered-list': block.type === BlockType.UnorderedList,
+        }"
+      >
+      <!-- Actual content -->
         <component :is="BlockComponents[props.block.type]" ref="content"
           :block="block" :readonly="props.readonly"
           @keydown="keyDownHandler"
@@ -71,6 +77,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  listIndex: {
+    type: Number,
+    default: null
+  }
 })
 
 const emit = defineEmits([

--- a/src/components/BlockMenu.vue
+++ b/src/components/BlockMenu.vue
@@ -9,7 +9,7 @@
     </div>
     <div v-show="open" class="block-menu">
       <div ref="menu"
-        class="w-[10rem] lg:w-[12rem] xl:w-[16rem] absolute z-10 shadow-block rounded py-1 text-neutral-700 text-sm right-full bg-white max-h-[24rem] overflow-auto focus-visible:outline-none top-0">
+        class="w-[10rem] lg:w-[12rem] xl:w-[16rem] absolute z-20 shadow-block rounded py-1 text-neutral-700 text-sm right-full bg-white max-h-[24rem] overflow-auto focus-visible:outline-none top-0">
         <div class="text-left divide-y">
           <!-- Search term -->
           <div v-if="searchTerm" class="block-menu-search px-2 py-2 flex gap-2 w-full">
@@ -20,7 +20,10 @@
           </div>
           <!-- Turn into another block like Text, Heading or Divider -->
           <div class="px-2 py-2" v-if="options.filter(option => option.type === 'Turn into').length">
-            <div class="px-2 pb-2 font-semibold uppercase text-xs text-neutral-400">Turn into</div>
+            <div class="flex justify-between px-2 pb-2 text-xs">
+              <div class="font-semibold uppercase text-neutral-500">Turn into</div>
+              <div class="text-neutral-300">Esc to Close</div>
+            </div>
             <div v-for="option, i in options.filter(option => option.type === 'Turn into')"
               class="px-2 py-1 rounded flex items-center gap-2"
               :class="[active === (i + options.filter(option => option.type !== 'Turn into').length) ? 'bg-neutral-100' : '']"

--- a/src/components/Lotion.vue
+++ b/src/components/Lotion.vue
@@ -11,10 +11,15 @@
     <draggable id="blocks" tag="div" :list="props.page.blocks"  handle=".handle"
       v-bind="dragOptions" class="space-y-2 pb-4">
       <transition-group type="transition">
-        <BlockComponent :block="block" v-for="block, i in props.page.blocks" :key="i" :id="'block-'+block.id"
+        <BlockComponent
+          v-for="block, i in props.page.blocks"
+          :key="block.id"
+          :id="'block-'+block.id"
+          :block="block"
           :blockTypes="props.blockTypes"
           :readonly="props.readonly"
-          :ref="el => blockElements[i] = (el as unknown as typeof Block)"
+          :listIndex="listIndex(i)"
+          :ref="(el: unknown) => blockElements[i] = (el as unknown as typeof Block)"
           @deleteBlock="deleteBlock(i)"
           @newBlock="insertBlock(i)"
           @moveToPrevChar="blockElements[i-1]?.moveToEnd(); scrollIntoView();"
@@ -23,15 +28,15 @@
           @moveToNextLine="blockElements[i+1]?.moveToFirstLine(); scrollIntoView();"
           @merge="merge(i)"
           @split="split(i)"
-          @setBlockType="type => setBlockType(i, type)"
-          />
+          @setBlockType="(type: BlockType) => setBlockType(i, type)"
+        />
       </transition-group>
     </draggable>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, onBeforeUpdate, PropType } from 'vue'
+import { ref, onBeforeUpdate, PropType, computed } from 'vue'
 import { VueDraggableNext as draggable } from 'vue-draggable-next'
 import { v4 as uuidv4 } from 'uuid'
 import { Block, BlockType, isTextBlock, availableBlockTypes } from '@/utils/types'
@@ -304,4 +309,20 @@ function splitTitle () {
   props.page.name = titleString.slice(0, caretPos)
   props.page.blocks[0].details.value = titleString.slice(caretPos)
 }
+
+function listIndex(i: number) {
+  let index = 0
+  let previousBlockType = null
+  for (let j = 0; j <= i; j++) {
+    if (props.page.blocks[j].type !== previousBlockType) {
+      index = 0
+    }
+    previousBlockType = props.page.blocks[j].type
+    if (props.page.blocks[j].type === BlockType.OrderedList) {
+      index++
+    }
+  }
+  return index
+}
+
 </script>

--- a/src/components/Lotion.vue
+++ b/src/components/Lotion.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="lotion w-[65ch] mx-auto my-24 font-sans text-base" v-if="props.page" ref="editor">
+  <div class="lotion w-[75ch] mx-auto my-24 font-sans text-base" v-if="props.page" ref="editor">
     <h1 id="title" ref="title" :contenteditable="!props.readonly" spellcheck="false" data-ph="Untitled"
       @keydown.enter.prevent="splitTitle"
       @keydown.down="blockElements[0]?.moveToFirstLine(); scrollIntoView();"
@@ -9,7 +9,7 @@
       {{ props.page.name || '' }}
     </h1>
     <draggable id="blocks" tag="div" :list="props.page.blocks"  handle=".handle"
-      v-bind="dragOptions" class="-ml-24 space-y-2 pb-4">
+      v-bind="dragOptions" class="space-y-2 pb-4">
       <transition-group type="transition">
         <BlockComponent :block="block" v-for="block, i in props.page.blocks" :key="i" :id="'block-'+block.id"
           :blockTypes="props.blockTypes"
@@ -175,10 +175,10 @@ function handleMoveToPrevLine (blockIdx:number) {
   scrollIntoView()
 }
 
-function insertBlock (blockIdx: number) {
+function insertBlock (blockIdx: number, type = BlockType.Text) {
   const newBlock = {
     id: uuidv4(),
-    type: BlockType.Text,
+    type,
     details: {
       value: '',
     },
@@ -280,7 +280,8 @@ function mergeTitle (blockIdx:number = 0) {
 
 function split (blockIdx: number) {
   const caretPos = blockElements.value[blockIdx].getCaretPos()
-  insertBlock(blockIdx)
+  const currentBlockType = props.page.blocks[blockIdx].type
+  insertBlock(blockIdx, currentBlockType)
   const blockTypeDetails = availableBlockTypes.find(blockType => blockType.blockType === props.page.blocks[blockIdx].type)
   if (!blockTypeDetails) return
   if (blockTypeDetails.canSplit) {

--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -50,43 +50,43 @@ const page = ref({
     id: uuidv4(),
     type: BlockType.Text,
     details: {
-      value: '1. Hover on the left of each line for quick actions'
+      value: 'Hover on the left of each line for quick actions'
     },
   }, {
     id: uuidv4(),
     type: BlockType.Text,
     details: {
-      value: '2. Click on the + button to add a new line'
+      value: 'Click on the + button to add a new line'
     },
   }, {
     id: uuidv4(),
     type: BlockType.Text,
     details: {
-      value: '3. Drag the ⋮⋮ button to reorder'
+      value: 'Drag the ⋮⋮ button to reorder'
     },
   }, {
     id: uuidv4(),
     type: BlockType.Text,
     details: {
-      value: '4. Click the trash icon to delete this block'
+      value: 'Click the trash icon to delete this block'
     },
   }, {
     id: uuidv4(),
-    type: BlockType.Text,
+    type: BlockType.OrderedList,
     details: {
-      value: '5. **Bold** and *italicize* using markdown e.g. \\*\\*bold\\*\\* and \\*italics\\*'
+      value: '**Bold** and *italicize* using markdown e.\\*\\*bold\\*\\* and \\*italics\\*'
     },
   }, {
     id: uuidv4(),
-    type: BlockType.Text,
+    type: BlockType.OrderedList,
     details: {
-      value: '6. Add headers and dividers with \'#\', \'##\' or \'---\' followed by a space'
+      value: 'Add headers and dividers with \'#\', \'##\' or \'---\' followed by a space'
     },
   }, {
     id: uuidv4(),
-    type: BlockType.Text,
+    type: BlockType.OrderedList,
     details: {
-      value: '7. Type \'/\' for a menu to quickly switch blocks and search by typing'
+      value: 'Type \'/\' for a menu to quickly switch blocks and search by typing'
     },
   },]
 })

--- a/src/components/blocks/DividerBlock.vue
+++ b/src/components/blocks/DividerBlock.vue
@@ -1,13 +1,12 @@
 <template>
-  <div class="w-full py-0 h-[1px] bg-neutral-300 mt-[1.2rem]">
-  </div>
+  <div class="w-full py-0 h-[1px] bg-neutral-300 mt-5"></div>
 </template>
 
 <script setup lang="ts">
 import { PropType } from 'vue'
 import { Block } from '@/utils/types'
 
-const props = defineProps({
+defineProps({
   block: {
     type: Object as PropType<Block>,
     required: true,

--- a/src/components/blocks/HeadingBlock.vue
+++ b/src/components/blocks/HeadingBlock.vue
@@ -14,7 +14,7 @@
 import { ref, PropType } from 'vue'
 import { Block, BlockType } from '@/utils/types'
 
-const headingConfig = {
+const headingConfig: Record<string, { placeholder: string, class: string } | null> = {
   [BlockType.H1]: {
     placeholder: 'Heading 1',
     class: 'text-4xl font-semibold',

--- a/src/index.css
+++ b/src/index.css
@@ -41,3 +41,17 @@ pre.lotion-md {
   pointer-events: none;
   height: 0;
 }
+
+.list-marker.ordered-list::before {
+  content: attr(data-index) ".";
+  position: absolute;
+  left: 0;
+  @apply py-1.5 text-neutral-600 left-0 absolute w-7 pr-1 text-right tabular-nums;
+}
+
+.list-marker.unordered-list::before {
+  content: "•";
+  position: absolute;
+  left: 0;
+  @apply py-1.5 text-neutral-600 left-0 absolute w-6 text-right tabular-nums;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,9 @@ import {
   BiTypeH2,
   BiTypeH3,
   BiHr,
-  BiQuote
+  BiQuote,
+  BiListOl,
+  BiListUl,
 } from "oh-vue-icons/icons"
 import App from './App.vue'
 import './index.css'
@@ -25,7 +27,9 @@ addIcons(
   BiTypeH2,
   BiTypeH3,
   BiHr,
-  BiQuote
+  BiQuote,
+  BiListOl,
+  BiListUl,
 )
 
 const app = createApp(App)

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -8,7 +8,6 @@ export interface Block {
   id: string,
   type: BlockType;
   details: Details;
-  children?: Block[];
 }
 
 export enum BlockType {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,13 +1,14 @@
+import { Component } from 'vue'
 import TextBlock from '@/components/blocks/TextBlock.vue'
 import DividerBlock from '@/components/blocks/DividerBlock.vue'
 import HeadingBlock from '@/components/blocks/HeadingBlock.vue'
 import QuoteBlock from '@/components/blocks/QuoteBlock.vue'
 
-
 export interface Block {
   id: string,
   type: BlockType;
   details: Details;
+  children?: Block[];
 }
 
 export enum BlockType {
@@ -16,7 +17,9 @@ export enum BlockType {
   H2 = 'H2',
   H3 = 'H3',
   Divider = 'DIVIDER',
-  Quote = 'QUOTE'
+  Quote = 'QUOTE',
+  UnorderedList = 'UNORDERED_LIST',
+  OrderedList = 'ORDERED_LIST',
 }
 
 export interface Details {
@@ -24,16 +27,18 @@ export interface Details {
   blockTypes?: BlockType[];
 }
 
-export const BlockComponents = {
+export const BlockComponents: Record<string, Component> = {
   [BlockType.Text]: TextBlock,
   [BlockType.H1]: HeadingBlock,
   [BlockType.H2]: HeadingBlock,
   [BlockType.H3]: HeadingBlock,
   [BlockType.Divider]: DividerBlock,
   [BlockType.Quote]: QuoteBlock,
+  [BlockType.UnorderedList]: TextBlock,
+  [BlockType.OrderedList]: TextBlock,
 }
 
-export const textBlockMap = [BlockType.Text, BlockType.Quote]
+export const textBlockMap = [BlockType.Text, BlockType.Quote, BlockType.UnorderedList, BlockType.OrderedList]
 
 export const isTextBlock = (type: string) => {
   return textBlockMap.some(textBlock => textBlock === type)
@@ -76,5 +81,17 @@ export const availableBlockTypes = [
     label: 'Quote',
     blockType: BlockType.Quote,
     canSplit: true,
+  }, {
+    type: 'Turn into',
+    icon: 'bi-list-ol',
+    label: 'Ordered List',
+    blockType: BlockType.OrderedList,
+    canSplit: false,
+  }, {
+    type: 'Turn into',
+    icon: 'bi-list-ul',
+    label: 'Unordered List',
+    blockType: BlockType.UnorderedList,
+    canSplit: false,
   },
 ] as { type:string, icon:string, label:string, blockType:BlockType|string, canSplit:boolean }[]

--- a/tests/components/Block.test.ts
+++ b/tests/components/Block.test.ts
@@ -307,6 +307,54 @@ describe('Block.vue', () => {
     })
   })
 
+  it("should change to Ordered List on 1.", async () => {
+    const wrapper = mount(BlockComponent, {
+      global: {
+        stubs: ['v-icon'],
+      },
+      props: {
+        block: {
+          type: BlockType.Text,
+          details: {
+            value: '<p>1. Test</p>',
+          },
+        } as Block,
+      },
+    })
+    await new Promise<void>(r => {
+      setTimeout(async () => {
+        wrapper.vm.moveToEnd()
+        elementKeyup(wrapper.vm.content.$el, ' ')
+        expect(wrapper.emitted().setBlockType[0]).toEqual(['ORDERED_LIST'])
+        r()
+      }, 100)
+    })
+  })
+
+  it("should change to Unordered List on -", async () => {
+    const wrapper = mount(BlockComponent, {
+      global: {
+        stubs: ['v-icon'],
+      },
+      props: {
+        block: {
+          type: BlockType.Text,
+          details: {
+            value: '<p>- Test</p>',
+          },
+        } as Block,
+      },
+    })
+    await new Promise<void>(r => {
+      setTimeout(async () => {
+        wrapper.vm.moveToEnd()
+        elementKeyup(wrapper.vm.content.$el, ' ')
+        expect(wrapper.emitted().setBlockType[0]).toEqual(['UNORDERED_LIST'])
+        r()
+      }, 100)
+    })
+  })
+
   it("should render default blockType and content without props", async () => {
     const wrapper = mount(BlockComponent, {
       global: {

--- a/tests/unit/utils.test.ts
+++ b/tests/unit/utils.test.ts
@@ -8,6 +8,8 @@ test('isTextBlock should work for text blocks', () => {
   const knownTextBlocks = [
     BlockType.Text,
     BlockType.Quote,
+    BlockType.OrderedList,
+    BlockType.UnorderedList,
   ] as any[]
   Object.values(BlockType).forEach(type => {
     if (knownTextBlocks.includes(type as BlockType)) expect(isTextBlock(type)).toBeTruthy()

--- a/tests/utils/playwright.ts
+++ b/tests/utils/playwright.ts
@@ -39,6 +39,12 @@ export async function isBlockType (locator: Locator, type: BlockType) {
       let isQuote2 = await locator.locator('..').locator('..').evaluate(((el) => el.classList.contains('border-black')))
       result = isTextType2 && isQuote2
       break
+    case BlockType.OrderedList:
+      result = await locator.evaluate((el) => el.classList.contains('list-decimal'))
+      break
+    case BlockType.UnorderedList:
+      result = await locator.evaluate((el) => el.classList.contains('list-disc'))
+      break
   }
   return result
 }

--- a/tests/utils/testTypes.ts
+++ b/tests/utils/testTypes.ts
@@ -4,5 +4,7 @@ export enum BlockType {
   H2 = 'H2',
   H3 = 'H3',
   Divider = 'DIVIDER',
-  Quote = 'QUOTE'
+  Quote = 'QUOTE',
+  UnorderedList = 'UNORDERED_LIST',
+  OrderedList = 'ORDERED_LIST',
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5661040/220542998-6361845a-4be5-472a-ac28-b9decd201b75.png)

Attempting to make new feature.
- New ordered and unordered list block type, which uses TextBlock component plus styling
- Block split type defaults to current block type (text splits into text, list into list)
- Backspace on List turns block into Text, another Backspace merge removes the block
- Ordered list is triggered with `1. `, unordered by `- `

Problem:
- Ordered list doesn't reset correctly. Since I'm using CSS to achieve showing `div` as List here `list-item list-decimal` and `list-item list-disc`, the page div keeps the counter.
![wrong-counter](https://user-images.githubusercontent.com/5661040/220543461-5391cfab-b3f3-4bf9-8360-8c30fc129429.png)

Suggestion:
- Maybe we should attempt to use actual `ol ul li` tags